### PR TITLE
Adding build-essential to docker image

### DIFF
--- a/deploying-llamaindex-applications-on-aws-with-pulumi/app/Dockerfile
+++ b/deploying-llamaindex-applications-on-aws-with-pulumi/app/Dockerfile
@@ -2,6 +2,7 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY . .
+RUN apt update && apt install build-essential -y
 RUN pip install --requirement requirements.txt && pip cache purge
 ARG PORT
 EXPOSE ${PORT:-8000}


### PR DESCRIPTION
Without this build-essential, the build of the wheels can fail.  
Example:

```
  × Building wheel for chroma-hnswlib (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [60 lines of output]
      running bdist_wheel
      running build
      running build_ext
      creating tmp
...
          self.build_extensions()
        File "<string>", line 102, in build_extensions
        File "<string>", line 69, in cpp_flag
      RuntimeError: Unsupported compiler -- at least C++11 support is needed!
      [end of output]
```