### PR TITLE
Switch GitOps branch to main

### DIFF
--- a/zero-to-production-in-kubernetes/00-infrastructure/Pulumi.dev.yaml
+++ b/zero-to-production-in-kubernetes/00-infrastructure/Pulumi.dev.yaml
@@ -5,4 +5,4 @@ config:
   aws:region: eu-central-1
   zero-to-production-in-kubernetes-infra:clusterName: zero-to-prod-k8s
   zero-to-production-in-kubernetes-infra:gitRepoUrl: "https://github.com/pulumi/workshops"
-  zero-to-production-in-kubernetes-infra:gitRepoBranch: "dirien/zero-to-prod-k8s"
+  zero-to-production-in-kubernetes-infra:gitRepoBranch: "main"


### PR DESCRIPTION
## Summary

- Update `gitRepoBranch` in Pulumi.dev.yaml from `dirien/zero-to-prod-k8s` to `main` now that the workshop content has been merged via #208

## Test plan

- [ ] Run `pulumi up` to update Flux GitRepository source to track main branch