### PR TITLE
Bump helm charts + expose Flux UI + scrape OpenClaw (gke-workshop)

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - instance.yaml
+  - podmonitoring.yaml

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/podmonitoring.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/podmonitoring.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: gke-openclaw
+  namespace: openclaw
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: gke-openclaw
+  endpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/repository.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/repository.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 10m
   url: oci://ghcr.io/stefanprodan/charts/podinfo
   ref:
-    tag: "6.11.1"
+    tag: "6.11.2"

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/flux-web-lb.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/flux-web-lb.yaml
@@ -1,0 +1,19 @@
+---
+# Flux Operator web UI exposed via GCP Network Load Balancer.
+# The operator pod listens on 9080 internally; we surface it on :80 externally.
+# Anonymous flux-web-admin access is configured by the operator chart values
+# (set in 00-infrastructure/flux_operator.tf).
+apiVersion: v1
+kind: Service
+metadata:
+  name: flux-web-lb
+  namespace: flux-system
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: flux-operator
+  ports:
+    - name: http
+      port: 80
+      targetPort: 9080
+      protocol: TCP

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./openclaw-operator
+  - flux-web-lb.yaml

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/openclaw-operator/repository.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/openclaw-operator/repository.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 10m
   url: oci://ghcr.io/openclaw-rocks/charts/openclaw-operator
   ref:
-    tag: "0.24.2"
+    tag: "0.31.0"


### PR DESCRIPTION
## Summary

Three improvements to the `getting-started-with-kubernetes-google-cloud` workshop's GitOps content:

- **Bump Helm charts to latest**
  - `openclaw-operator` 0.24.2 → 0.31.0
  - `podinfo` 6.11.1 → 6.11.2
  - (`flux-operator` is bumped 0.45.1 → 0.48.0 in `00-infrastructure/flux_operator.tf` separately — that path is local-only, not on `main`.)
- **Expose the Flux Operator web UI** via a `LoadBalancer` Service `flux-web-lb` in `flux-system` (port 80 → operator pod `:9080`). Anonymous `flux-web-admin` access is already configured by the operator chart values in Terraform.
- **Scrape the OpenClaw instance metrics endpoint** (`:9090`, plain HTTP, served by the OTel-collector sidecar) via a `PodMonitoring` CR so Managed Prometheus collects gateway/agent metrics.

## Scope

Only files under `getting-started-with-kubernetes-google-cloud/01-gitops/` change. No other workshops touched.

## Test plan

- [ ] After merge, Flux GitRepository picks up `main` within 1 min, Kustomization `infrastructure` and `apps` reconcile within 10 min.
- [ ] `kubectl -n flux-system get svc flux-web-lb` shows an external IP.
- [ ] Browse to `http://<flux-web-lb-ip>` — Flux Operator dashboard renders.
- [ ] `kubectl -n openclaw get podmonitoring gke-openclaw` exists.
- [ ] `kubectl -n openclaw get pod gke-openclaw-0` rolls (operator chart upgrade); restart count stays low.
- [ ] `kubectl -n podinfo get helmrelease podinfo` shows revision with chart `podinfo@6.11.2`.
- [ ] In Cloud Monitoring → Metrics Explorer (PromQL), query `up{namespace="openclaw"}` returns `1`.