### PR TITLE
OpenClaw: switch to patched runtime image for Vertex AI / Workload Identity

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/instance.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/instance.yaml
@@ -5,12 +5,21 @@ metadata:
   name: gke-openclaw
   namespace: openclaw
 spec:
-  # GOOGLE_CLOUD_PROJECT is consumed by the google-vertex provider's
-  # Application Default Credentials path. The token itself is provided by
-  # GKE Workload Identity via the annotated ServiceAccount below.
+  # Custom OpenClaw runtime image with two upstream pi-ai bug fixes that
+  # together let the bundled google-vertex provider use GKE Workload
+  # Identity / ADC end-to-end. Source + Dockerfile under
+  # 00-infrastructure/openclaw-vertex-adc-fix/.
+  # Tracking issue: https://github.com/openclaw/openclaw/issues/49191
+  image: "ghcr.io/dirien/openclaw:2026.5.7-vertex-adc-fix.1"
+
+  # Pod-level env. Both project and location must be set; pi-ai's
+  # getEnvApiKey("google-vertex") returns the "<authenticated>" sentinel
+  # only when both are present.
   env:
     - name: GOOGLE_CLOUD_PROJECT
       value: "${gcp_project_id}"
+    - name: GOOGLE_CLOUD_LOCATION
+      value: "global"
   security:
     rbac:
       serviceAccountAnnotations:
@@ -18,12 +27,18 @@ spec:
   config:
     mergeMode: merge
     raw:
+      # Propagated to OpenClaw agent subprocesses so they see the same
+      # GOOGLE_CLOUD_* values the gateway sees.
+      env:
+        vars:
+          GOOGLE_CLOUD_PROJECT: "${gcp_project_id}"
+          GOOGLE_CLOUD_LOCATION: "global"
       models:
         providers:
           google-vertex:
             # Vertex AI publisher endpoint, project-scoped. ADC token is
-            # obtained automatically by the SDK via the Workload-Identity-bound
-            # GSA. No API key.
+            # obtained automatically by @google/genai via the
+            # Workload-Identity-bound GSA — no API key.
             baseUrl: "https://aiplatform.googleapis.com/v1/projects/${gcp_project_id}/locations/global/publishers/google/models"
             models:
               - id: "gemini-2.5-flash"


### PR DESCRIPTION
## Summary

Switch the workshop's `OpenClawInstance` to a custom OpenClaw runtime image that has two upstream `@mariozechner/pi-ai` bug fixes applied. Together they make the bundled `google-vertex` provider use **GKE Workload Identity / ADC end-to-end** — no API key on disk, no service-account JSON file.

Upstream bug, still open: [openclaw/openclaw#49191](https://github.com/openclaw/openclaw/issues/49191)

## What changed

`getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/openclaw/instance.yaml`:

- **`spec.image`** → `ghcr.io/dirien/openclaw:2026.5.7-vertex-adc-fix.1` (the patched image)
- **`spec.env`** → adds `GOOGLE_CLOUD_LOCATION=global` (pi-ai requires both project AND location to emit the auth sentinel)
- **`spec.config.raw.env.vars`** → duplicates `GOOGLE_CLOUD_*` into `openclaw.json` so agent subprocesses inherit them

The Dockerfile + `build-and-push.sh` for the patched image live at `getting-started-with-kubernetes-google-cloud/00-infrastructure/openclaw-vertex-adc-fix/` (local, not on `main`). Run `./build-and-push.sh` before merging this PR.

## The two patches inside the image

1. **`env-api-keys.js`** — drop the `hasCredentials` requirement so the `<authenticated>` sentinel is emitted when project + location are set, no credentials file required (Workload Identity gets the token from the GCE metadata server, no JSON file needed).
2. **`providers/google-vertex.js`** — skip the `apiKey` routing branch when the apiKey is the `<authenticated>` sentinel, so requests flow through `createClient(model, project, location)` instead of `createClientWithApiKey(model, apiKey)` (which targets Vertex AI Express without project/location in the URL — that's the 404 source).

After both: `pi-ai → @google/genai → google-auth-library → GCE metadata server (Workload Identity) → Vertex AI publishers/google/models`.

## Honest disclaimer

Live empirical validation in the running cluster wasn't possible — the OpenClaw operator strips custom `initContainers`/`extraVolumes` on reconcile, and the read-only root FS forbids in-place sed. **Final validation is the deployment itself**: after the image is pushed and the PR merges, Flux rolls the StatefulSet over and we either see Gemini reply or learn something new from the new error message. The patches' contents are correct per source-trace ([@GMTekAI's analysis in #49191](https://github.com/openclaw/openclaw/issues/49191)) and the Dockerfile validates each patch was applied successfully (`grep -q` guards before and after `sed`).

## Test plan

- [ ] Run `./build-and-push.sh` from `00-infrastructure/openclaw-vertex-adc-fix/` to build + push the image to `ghcr.io/dirien/openclaw:2026.5.7-vertex-adc-fix.1`
- [ ] Merge this PR
- [ ] Wait ~2 min for Flux GitRepository → Kustomization → OpenClaw operator → StatefulSet rollout
- [ ] `kubectl -n openclaw get pod gke-openclaw-0` — image should be the patched one, restarts ≤ 1
- [ ] `kubectl -n openclaw logs gke-openclaw-0 -c openclaw --tail=20 | grep "agent model"` — confirms gateway loaded
- [ ] `kubectl -n openclaw exec gke-openclaw-0 -c openclaw -- openclaw agent --agent main -m "say only: pong"` — should return Gemini's response, no `No API key found` error
- [ ] If the patches are insufficient, capture the new error from the gateway logs and iterate