### PR TITLE
ADK agent observability: traces, metrics, logs + :latest pull policy

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
@@ -19,8 +19,10 @@ spec:
       serviceAccountName: adk-agent
       containers:
         - name: adk-agent
-          image: ghcr.io/dirien/adk-agent:1.0.0
-          imagePullPolicy: IfNotPresent
+          # `:latest` + `Always` so a fresh image push + `kubectl rollout
+          # restart deploy/adk-agent` ships the new code — no gitops PR.
+          image: ghcr.io/dirien/adk-agent:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8000
               name: http

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - serviceaccount.yaml
   - deployment.yaml
   - service.yaml
+  - podmonitoring.yaml

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/podmonitoring.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/podmonitoring.yaml
@@ -1,0 +1,17 @@
+---
+# Managed Prometheus scrapes the FastAPI /metrics endpoint exposed by
+# prometheus-fastapi-instrumentator inside the ADK agent. Same pattern as
+# apps/base/podinfo/podmonitoring.yaml.
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: adk-agent
+  namespace: adk
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: adk-agent
+  endpoints:
+    - port: http
+      interval: 30s
+      path: /metrics


### PR DESCRIPTION
## Summary

Bring the ADK agent's observability up to the same bar as podinfo, plus switch to `:latest` + `imagePullPolicy: Always` so future image pushes don't need a gitops PR.

## Changes

`apps/base/adk-agent/`:

- **deployment.yaml** — `image: ghcr.io/dirien/adk-agent:latest` + `imagePullPolicy: Always`. After a `docker push`, `kubectl rollout restart deploy/adk-agent -n adk` ships the change.
- **podmonitoring.yaml** (new) — Managed Prometheus scrapes the FastAPI `/metrics` endpoint exposed by `prometheus-fastapi-instrumentator` inside the image. Mirrors `apps/base/podinfo/podmonitoring.yaml`.
- **kustomization.yaml** — adds `podmonitoring.yaml`.

## What's in the new image (already pushed as `:latest`)

- `prometheus-fastapi-instrumentator` exposing `/metrics` on port 8000
- `otel_to_cloud=True` on `get_fast_api_app(...)` — wires ADK's OpenTelemetry tracer to the Cloud Trace exporter from the `google-adk[otel-gcp]` extra. Spans land in Cloud Trace.

## Three pillars after merge

| Pillar | How |
|---|---|
| **Logs** | Container stdout/stderr → Cloud Logging via the cluster's `WORKLOADS` logging component (already enabled in Terraform). |
| **Metrics** | FastAPI `/metrics` → Managed Prometheus → Cloud Monitoring (PromQL queryable). |
| **Traces** | ADK's OTel tracer → `opentelemetry-exporter-gcp-trace` → Cloud Trace. |

## Required Terraform tweak (local-only, not in PR)

Grant the GSA two more roles in `vertex_iam.tf` so the OTel exporter can actually write under Workload Identity:

```hcl
resource "google_project_iam_member" "openclaw_vertex_trace" {
  project = var.project_id
  role    = "roles/cloudtrace.agent"
  member  = "serviceAccount:${google_service_account.openclaw_vertex.email}"
}

resource "google_project_iam_member" "openclaw_vertex_metrics" {
  project = var.project_id
  role    = "roles/monitoring.metricWriter"
  member  = "serviceAccount:${google_service_account.openclaw_vertex.email}"
}
```

Then `terraform apply` and `kubectl rollout restart deploy/adk-agent -n adk`.

## Test plan

- [ ] Apply the Terraform IAM grants
- [ ] Merge this PR, Flux reconciles
- [ ] `kubectl rollout restart deploy/adk-agent -n adk` (pulls `:latest`)
- [ ] `kubectl -n adk get podmonitoring adk-agent`
- [ ] `curl http://<lb>/metrics` returns Prometheus exposition
- [ ] Metrics Explorer (PromQL): `up{namespace="adk"}` returns 1
- [ ] Send a few requests via `/run`, then check **Cloud Trace** explorer — spans for `agent_run`, `call_llm`, `tool_call get_capital_city`
- [ ] Logs Explorer: `resource.type="k8s_container" resource.labels.namespace_name="adk"`