### PR TITLE
Rename openclaw-vertex GSA reference to adk-vertex in adk-agent KSA

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/serviceaccount.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/serviceaccount.yaml
@@ -9,4 +9,4 @@ metadata:
   name: adk-agent
   namespace: adk
   annotations:
-    iam.gke.io/gcp-service-account: "openclaw-vertex@${gcp_project_id}.iam.gserviceaccount.com"
+    iam.gke.io/gcp-service-account: "adk-vertex@${gcp_project_id}.iam.gserviceaccount.com"


### PR DESCRIPTION
## Summary
- The OpenClaw → ADK rename in #216 left the Workload Identity annotation in `adk-agent/serviceaccount.yaml` pointing at the old `openclaw-vertex` GSA email.
- Update the KSA annotation to match the renamed GSA. The matching Terraform-side rename (resource addresses + `account_id`) lands separately in `00-infrastructure/vertex_iam.tf` since nothing is currently deployed.

## Test plan
- [ ] `make lint` passes (no new violations introduced)
- [ ] After Terraform apply renames the GSA to `adk-vertex@<project>.iam.gserviceaccount.com`, Flux reconciles this manifest and the `adk-agent` pod successfully gets a Vertex AI access token via Workload Identity