### PR TITLE
Harden GKE workshop: PSA, quotas, NetworkPolicies, CCNP

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
@@ -17,12 +17,30 @@ spec:
         app.kubernetes.io/name: adk-agent
     spec:
       serviceAccountName: adk-agent
+      # Pod-level securityContext required by PSA `restricted` on the
+      # namespace. The image's USER myuser already runs non-root; this
+      # makes that explicit to the kubelet and admission controller.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: adk-agent
           # `:latest` + `Always` so a fresh image push + `kubectl rollout
           # restart deploy/adk-agent` ships the new code — no gitops PR.
           image: ghcr.io/dirien/adk-agent:latest
           imagePullPolicy: Always
+          # Container-level securityContext to satisfy PSA `restricted`:
+          # drop all caps, deny privilege escalation. Port 8000 is >1024
+          # so we don't need NET_BIND_SERVICE back.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: 8000
               name: http

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - podmonitoring.yaml
+  - limits.yaml
+  - networkpolicy.yaml

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/limits.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/limits.yaml
@@ -1,0 +1,36 @@
+---
+# LimitRange: per-container defaults + max. Kicks in BEFORE the
+# ResourceQuota admission check, so existing deployments without explicit
+# requests/limits don't get rejected the moment the quota lands.
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: defaults
+  namespace: adk
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      max:
+        cpu: "2"
+        memory: 4Gi
+---
+# ResourceQuota: total budget for the namespace. Stops a single
+# misbehaving workload (or a runaway HPA) from consuming the cluster.
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: tenant-quota
+  namespace: adk
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    pods: "20"

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/namespace.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/namespace.yaml
@@ -3,3 +3,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: adk
+  labels:
+    # Pod Security Admission — built into the kube-apiserver, no controller
+    # to install. The ADK agent's container image (Alpine, USER myuser,
+    # port 8000) passes `restricted` once the deployment carries an explicit
+    # securityContext, so we enforce the strictest profile here.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/networkpolicy.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/networkpolicy.yaml
@@ -1,0 +1,113 @@
+---
+# DNS: every pod needs to resolve names. kube-dns runs in kube-system.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-dns
+  namespace: adk
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+# Workload Identity: the ADK agent calls Vertex AI / Cloud Trace under WI,
+# which means hitting the GKE metadata server (169.254.169.254). The
+# CiliumClusterwideNetworkPolicy in infrastructure/base denies this
+# everywhere by default; this policy explicitly allows it for the adk
+# namespace via Cilium's CIDR-egress support, layered on top.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-metadata-server
+  namespace: adk
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: adk-agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+---
+# Vertex AI / Cloud Trace / Cloud Logging / Cloud Monitoring all ride on
+# *.googleapis.com over HTTPS. Allowing 443 to anywhere is broader than
+# strict production wants, but it's the cleanest workshop posture without
+# pinning Google IP ranges that drift. For a tighter posture, swap for an
+# FQDN policy (Dataplane V2 supports them).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-https
+  namespace: adk
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: adk-agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              # Block egress back into the cluster network and metadata IP.
+              # Per-namespace traffic stays governed by the cluster's own
+              # NetworkPolicy posture, not this allow rule.
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.169.254/32
+      ports:
+        - protocol: TCP
+          port: 443
+---
+# Managed Prometheus collector lives in gmp-system and scrapes /metrics on
+# port 8000 (the FastAPI app exposes it via prometheus-fastapi-instrumentator).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-monitoring
+  namespace: adk
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: adk-agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gmp-system
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+# Default-deny baseline: any traffic not explicitly allowed above is
+# dropped. Lands LAST in the document so the allow-rules above are
+# evaluated first when the apiserver admits the bundle.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: adk
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - repository.yaml
   - release.yaml
   - podmonitoring.yaml
+  - limits.yaml
+  - networkpolicy.yaml

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/limits.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/limits.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: defaults
+  namespace: podinfo
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 256Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 64Mi
+      max:
+        cpu: "1"
+        memory: 1Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: tenant-quota
+  namespace: podinfo
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 4Gi
+    limits.cpu: "8"
+    limits.memory: 8Gi
+    # podinfo HPA scales up to 10 replicas; cap at 25 leaves headroom for
+    # rollouts and surge.
+    pods: "25"

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/namespace.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/namespace.yaml
@@ -3,3 +3,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: podinfo
+  labels:
+    # Pod Security Admission. Podinfo's chart defaults pass `baseline`
+    # cleanly; `restricted` would require pinning extra securityContext
+    # values that drift on chart upgrades, so we enforce baseline and
+    # surface any restricted-level violations via audit + warn instead of
+    # blocking deploys.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/networkpolicy.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/podinfo/networkpolicy.yaml
@@ -1,0 +1,76 @@
+---
+# DNS for kube-dns lookups.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-dns
+  namespace: podinfo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+---
+# Public LoadBalancer demo — anyone on the internet can hit podinfo on
+# port 9898. Production posture would scope this to known CIDRs or run it
+# behind an ingress with WAF rules.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-http
+  namespace: podinfo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9898
+---
+# Managed Prometheus collector scrape on port 9797 (podinfo metrics port).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-monitoring
+  namespace: podinfo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: podinfo
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gmp-system
+      ports:
+        - protocol: TCP
+          port: 9797
+---
+# Default-deny baseline: drop anything not explicitly allowed above.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: podinfo
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/cilium-clusterwide-policy.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/cilium-clusterwide-policy.yaml
@@ -1,0 +1,27 @@
+---
+# Block egress to the GCE metadata server (169.254.169.254) cluster-wide,
+# except from namespaces that legitimately need it:
+#   * kube-system  — hosts the gke-metadata-server DaemonSet, the GKE
+#                    component that intercepts WI requests.
+#   * adk          — the ADK agent uses Workload Identity to call Vertex
+#                    AI / Cloud Trace / Cloud Monitoring.
+#
+# Defense-in-depth: even with PSA + per-namespace NetworkPolicies, an
+# unrestricted route to the metadata server is a classic SSRF target. A
+# CiliumClusterwideNetworkPolicy enforces a baseline that namespace owners
+# can't accidentally weaken with their own policies.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: deny-egress-gce-metadata
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - adk
+  egressDeny:
+    - toCIDR:
+        - 169.254.169.254/32

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flux-web-lb.yaml
+  - cilium-clusterwide-policy.yaml


### PR DESCRIPTION
## Summary

Production-close hardening for the GKE workshop's GitOps tree. Pairs with cluster-side enablement of Dataplane V2 and system/workload/spot node-pool split in `00-infrastructure` (handled separately, no PR needed since that's still local infra rework).

### Pod Security Admission
- `adk`     — `enforce / audit / warn = restricted`. The ADK agent's Dockerfile already runs `USER myuser` on Alpine + port 8000 (>1024, no `NET_BIND_SERVICE`), so the deployment just needed an explicit `securityContext` block (drop ALL caps, `runAsNonRoot`, `RuntimeDefault` seccomp, no privilege escalation).
- `podinfo` — `enforce = baseline`, `audit / warn = restricted`. Stefan Prodan's chart defaults pass baseline cleanly; tighter enforce would drift on chart upgrades, so we surface restricted-level issues via audit/warn instead of blocking deploys.

### Resource governance
- `LimitRange` per namespace with sensible defaults / max — applied **before** `ResourceQuota` so existing pods aren't rejected the moment the quota's cpu/memory tracking lands.
- `ResourceQuota` per namespace caps total cpu / memory / pods. Stops a runaway HPA or misbehaving workload from consuming the cluster.

### NetworkPolicies (Dataplane V2)
- Per-namespace explicit allows: DNS to kube-dns, Managed Prometheus ingress from `gmp-system`, app port ingress, googleapis-class egress on 443, metadata-server egress for the ADK agent only.
- Default-deny baseline drops anything not explicitly allowed.

### CiliumClusterwideNetworkPolicy (CCNP)
- Denies pod egress to `169.254.169.254/32` cluster-wide **except** `kube-system` (the `gke-metadata-server` DaemonSet) and `adk` (Workload Identity via the ADK agent). Defense-in-depth against SSRF / pod-escape attempts at the metadata-server endpoint.

## Files

```
01-gitops/apps/base/adk-agent/
  namespace.yaml          (PSA labels)
  deployment.yaml         (securityContext)
  limits.yaml             NEW
  networkpolicy.yaml      NEW
  kustomization.yaml      (+ limits, networkpolicy)
01-gitops/apps/base/podinfo/
  namespace.yaml          (PSA labels)
  limits.yaml             NEW
  networkpolicy.yaml      NEW
  kustomization.yaml      (+ limits, networkpolicy)
01-gitops/infrastructure/base/
  cilium-clusterwide-policy.yaml   NEW
  kustomization.yaml      (+ cilium-clusterwide-policy)
```

## Test plan
- [ ] `kustomize build 01-gitops/apps/base/adk-agent` succeeds
- [ ] `kustomize build 01-gitops/apps/base/podinfo` succeeds
- [ ] `kustomize build 01-gitops/infrastructure/base` succeeds
- [ ] On a Dataplane V2 cluster with the matching 00-infrastructure changes applied:
  - `kubectl get ns adk -o jsonpath='{.metadata.labels}'` shows PSA labels
  - `kubectl -n adk describe deploy adk-agent` shows pod admission with restricted profile passing
  - `kubectl -n adk get networkpolicy` lists the 5 policies
  - `kubectl get ciliumclusterwidenetworkpolicy deny-egress-gce-metadata`
  - The ADK agent successfully gets a Vertex AI access token (Workload Identity not blocked)
  - podinfo `/metrics` is reachable from `gmp-system` collector pods (via Managed Prometheus dashboard)
- [ ] `make lint` passes (no new violations)