### PR TITLE
Fix adk-agent CreateContainerConfigError under PSA restricted

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/deployment.yaml
@@ -18,10 +18,17 @@ spec:
     spec:
       serviceAccountName: adk-agent
       # Pod-level securityContext required by PSA `restricted` on the
-      # namespace. The image's USER myuser already runs non-root; this
-      # makes that explicit to the kubelet and admission controller.
+      # namespace. The image's Dockerfile declares `USER myuser` (a name,
+      # not a UID), so kubelet can't *verify* non-root from the image
+      # config alone — `runAsNonRoot: true` admission passes but the
+      # container fails to start with "image has non-numeric user". Set
+      # runAsUser explicitly to the UID Alpine's adduser assigned to
+      # myuser (1000 — verified with `docker run --entrypoint id`).
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary

The `adk-agent` Deployment from #219 fails to start with:

\`\`\`
Error: container has runAsNonRoot and image has non-numeric user (myuser), cannot verify user is non-root
\`\`\`

The image's Dockerfile declares \`USER myuser\` (a name, not a UID). PSA admission passes because \`runAsNonRoot: true\` is set, but the kubelet refuses to start the container — it can't *verify* non-root from a string username in the image config.

Fix: set \`runAsUser: 1000\` (verified with \`docker run --entrypoint id ghcr.io/dirien/adk-agent:latest\` → \`uid=1000(myuser)\`). Also pin \`runAsGroup\` and \`fsGroup\` so the Dockerfile's \`COPY --chown=myuser:myuser\` lines up at runtime.

## Test plan
- [ ] Flux reconciles the change, the new \`adk-agent\` ReplicaSet rolls out
- [ ] \`kubectl -n adk get pods\` shows the pod \`Running 1/1\`
- [ ] \`apps\` Kustomization moves to \`Ready=True\`
- [ ] ADK web UI reachable on the LoadBalancer (or via \`kubectl -n adk port-forward svc/adk-agent 8000:8000\`)