### PR TITLE
Allow external LoadBalancer ingress to flux-web and adk-agent

### DIFF
--- a/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/networkpolicy.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/apps/base/adk-agent/networkpolicy.yaml
@@ -98,6 +98,27 @@ spec:
         - protocol: TCP
           port: 8000
 ---
+# Public LoadBalancer demo — the adk-agent Service is type LoadBalancer and
+# the workshop hands out the external IP for browser/curl access. Without a
+# `from` clause, the rule allows traffic from any source (including external
+# clients via the GCP NLB), keeping the default-deny baseline elsewhere.
+# Production posture: scope to known CIDRs or front with IAP / Cloud Armor.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-http
+  namespace: adk
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: adk-agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8000
+---
 # Default-deny baseline: any traffic not explicitly allowed above is
 # dropped. Lands LAST in the document so the allow-rules above are
 # evaluated first when the apiserver admits the bundle.

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/flux-web-allow-external.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/flux-web-allow-external.yaml
@@ -1,0 +1,31 @@
+---
+# The flux-operator Helm chart ships its own NetworkPolicy
+# (`flux-operator-web`) that allows ingress to port 9080 only from
+# `namespaceSelector: {}` — i.e. in-cluster pods in any namespace.
+# External LoadBalancer traffic has no source pod and gets dropped.
+#
+# This policy adds a parallel rule with no `from` clause, allowing the
+# flux-web-lb Service (Network LB → pod port 9080) to actually reach the
+# operator's web UI from the public internet. K8s NetworkPolicy is
+# additive — both rules apply, and traffic matching either is allowed.
+#
+# Production posture: drop this policy and use port-forward, IAP, or a
+# VPN. The Flux Operator UI shows full GitOps state including source
+# URLs and policy bindings — exposing it on a public LB without auth is
+# a real security gap, only acceptable for short-lived workshop clusters.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-flux-web-external
+  namespace: flux-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: flux-operator
+      app.kubernetes.io/name: flux-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9080

--- a/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
+++ b/getting-started-with-kubernetes-google-cloud/01-gitops/infrastructure/base/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - flux-web-lb.yaml
+  - flux-web-allow-external.yaml
   - cilium-clusterwide-policy.yaml


### PR DESCRIPTION
## Summary

Both LoadBalancer-exposed UIs were unreachable externally because the existing NetworkPolicies only permit *in-cluster* sources:

- `adk` namespace: the `default-deny` from #219 + `allow-ingress-monitoring` (only allows from `gmp-system`) → external LB traffic dropped at pod boundary.
- `flux-system` namespace: the flux-operator chart's own `flux-operator-web` NetworkPolicy uses `from: namespaceSelector: {}`, which matches in-cluster pods only.

Add two NetworkPolicies with no `from:` clause (any source allowed) on the relevant pod ports so the public LB IPs actually work:

| Namespace | Policy | Pod | Port |
|---|---|---|---|
| `adk` | `allow-ingress-http` | `app.kubernetes.io/name=adk-agent` | 8000 |
| `flux-system` | `allow-ingress-flux-web-external` | `app.kubernetes.io/name=flux-operator` | 9080 |

K8s NetworkPolicy is additive — these layer on top of existing rules without weakening monitoring scrape, default-deny egress posture, or the CCNP metadata-server lockdown.

## Production note

These policies expose the Flux Operator UI (full GitOps state, source URLs, secrets references) and an unauthenticated ADK agent (prompt abuse, Vertex AI cost) on public anycast LBs. Acceptable for short-lived workshop clusters; for production drop both and use port-forward, IAP, or a VPN. The PR's YAML comments call this out.

## Test plan
- [ ] After merge + Flux reconcile, `curl http://<flux-web-lb-ip>/` reaches the operator web UI
- [ ] `curl http://<adk-lb-ip>/list-apps` returns `["capital_agent"]`
- [ ] `kubectl -n flux-system get networkpolicy` shows `allow-ingress-flux-web-external`
- [ ] `kubectl -n adk get networkpolicy` shows `allow-ingress-http`
- [ ] Managed Prometheus collectors still scrape /metrics (existing `allow-ingress-monitoring` policy intact)