### PR TITLE
Drop CLAUDE.md symlink so subpath component publishes work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
## Summary

Removes the \`CLAUDE.md → AGENTS.md\` symlink at the repo root. Unblocks \`pulumi package publish\` for any subpath-hosted component in this monorepo.

## Why

Pulumi's \`pulumi package publish <repo-url>/<subpath>@<tag>\` downloads the *whole* repo tarball before scoping into the subpath. Pulumi's tarball extractor rejects symlinks with:

\`\`\`
unexpected plugin file type CLAUDE.md (50)
\`\`\`

(\`50\` is ASCII \`'2'\`, the tar \`typeflag\` value for symlink.)

This regressed publishing after #207 added \`AGENTS.md\` + the symlink at root. Existing v0.x tags before #207 (\`kagent-agent\` v0.4.0, \`kubernetes-cluster\` v0.5.1) published cleanly because the symlink wasn't there.

## Why removing the symlink is fine

Both AI agents that read these files already fall back gracefully:

- **Claude Code** reads \`CLAUDE.md\` if present, else \`AGENTS.md\`
- **OpenAI Codex / Cursor / others** read \`AGENTS.md\` directly

So a single \`AGENTS.md\` covers both ecosystems and unblocks Pulumi publishing.

## Test plan

- [ ] After merge, tag \`v0.6.0\` on the merge commit
- [ ] \`pulumi package publish https://github.com/pulumi/workshops/getting-started-with-kubernetes-google-cloud/02-component@0.6.0 --publisher lumitorch\` succeeds
- [ ] AI agents (Claude Code) still pick up agent rules from \`AGENTS.md\` (verified locally — Claude reads AGENTS.md when CLAUDE.md is absent)